### PR TITLE
Potential fix for code scanning alert no. 58: Query built from user-controlled sources

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/sqlinjection/mitigation/Servers.java
+++ b/src/main/java/org/owasp/webgoat/lessons/sqlinjection/mitigation/Servers.java
@@ -45,12 +45,16 @@ public class Servers {
   public List<Server> sort(@RequestParam String column) throws Exception {
     List<Server> servers = new ArrayList<>();
 
+    // Whitelist of allowed column names
+    List<String> allowedColumns = List.of("id", "hostname", "ip", "mac", "status", "description");
+    if (!allowedColumns.contains(column)) {
+      throw new IllegalArgumentException("Invalid column name");
+    }
+
     try (var connection = dataSource.getConnection()) {
-      try (var statement =
-          connection.prepareStatement(
-              "select id, hostname, ip, mac, status, description from SERVERS where status <> 'out"
-                  + " of order' order by "
-                  + column)) {
+      String query =
+          "select id, hostname, ip, mac, status, description from SERVERS where status <> 'out of order' order by " + column;
+      try (var statement = connection.prepareStatement(query)) {
         try (var rs = statement.executeQuery()) {
           while (rs.next()) {
             Server server =


### PR DESCRIPTION
Potential fix for [https://github.com/arsenslyusarchukeleks/WebGoatTest/security/code-scanning/58](https://github.com/arsenslyusarchukeleks/WebGoatTest/security/code-scanning/58)

To fix this problem, we need to ensure that the user-supplied `column` value cannot be used to inject malicious SQL. Since JDBC does not allow parameterizing column names, the best approach is to validate the `column` parameter against a whitelist of allowed column names before using it in the query. Only if the provided value matches one of the expected column names should it be used; otherwise, the request should be rejected or a default column should be used. This change should be made in the `sort` method in `src/main/java/org/owasp/webgoat/lessons/sqlinjection/mitigation/Servers.java`. We will define a list of allowed column names, check if the user input matches one of them, and use the validated value in the query. If the value is invalid, we can throw an exception or return an empty list.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
